### PR TITLE
Bump version to 0.43.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if DEVELOPER_MODE:
 # to work properly
 sys.path.insert(0, os.path.join(basedir, 'src'))
 
-LLFUSE_VERSION = '0.42.1'
+LLFUSE_VERSION = '0.43'
 
 def main():
 


### PR DESCRIPTION
Verison bump is required so that s3ql works with llfuse from master.