### PR TITLE
sync to attr from 2015-04-14

### DIFF
--- a/src/xattr.h
+++ b/src/xattr.h
@@ -25,7 +25,10 @@
  * Linux
  */
 #if PLATFORM == PLATFORM_LINUX
-#include <attr/xattr.h>
+#ifndef ENOATTR
+# define ENOATTR ENODATA
+#endif
+#include <sys/xattr.h>
 
 #define EXTATTR_NAMESPACE_USER 0
 #define EXTATTR_NAMESPACE_SYSTEM 0


### PR DESCRIPTION
Hallo,
  in the current state of attr(http://git.savannah.gnu.org/cgit/attr.git)  the  include file "attr/xattr.h" don't exist any more.
 So just small fix to make llfuse compilable with current attr
