### PR TITLE
btw: why the prior commit still here among this pr?

### DIFF
--- a/rst/install.rst
+++ b/rst/install.rst
@@ -63,7 +63,7 @@ Development Version
 ===================
 
 If you have checked out the unstable development version from the
-Mercurial repository, a bit more effort is required. You need to also
+repository ( Mercurial_ or Git_ ), a bit more effort is required. You need to also
 have Cython_ (0.24 or newer) and Sphinx_ (1.1 or newer) installed, and
 the necessary commands are::
 
@@ -86,3 +86,5 @@ the necessary commands are::
 .. _OSXFUSE: http://osxfuse.github.io/
 .. _setuptools: https://pypi.python.org/pypi/setuptools
 .. _contextlib2: https://pypi.python.org/pypi/contextlib2/
+.. _Mercurial: https://bitbucket.org/nikratio/python-llfuse
+.. _Git: https://github.com/python-llfuse/python-llfuse

--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -233,7 +233,7 @@ def init(ops, mountpoint, options=default_options):
         my_opts = set(llfuse.default_options)
         my_opts.add('allow_other')
         my_opts.discard('default_permissions')
-        llfuse.init(ops, mountpoint, my_apts)
+        llfuse.init(ops, mountpoint, my_opts)
 
     Valid options are listed under ``struct
     fuse_opt fuse_mount_opts[]``

--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -130,7 +130,7 @@ def getxattr(path, name, size_t size_guess=128, namespace='user'):
     select the namespace for the extended attribute. For other platforms, this
     parameter is ignored.
 
-    In contrast the `os.setxattr` function from the standard library,
+    In contrast the `os.getxattr` function from the standard library,
     the method provided by Python-LLFUSE is also available for non-Linux
     systems.
     '''

--- a/src/operations.pxi
+++ b/src/operations.pxi
@@ -312,8 +312,8 @@ class Operations(object):
         *fh* will by an integer filehandle returned by a prior `open` or
         `create` call.
 
-        This method must returns the number of bytes written. However, uuless
-        the file system has been mounted with the ``direct_io`` option, the file
+        This method must returns the number of bytes written. However, unless
+        the file system has been mounted without the ``direct_io`` option, the file
         system *must* always write *all* the provided data (i.e., return
         ``len(buf)``).
         '''


### PR DESCRIPTION
uuless the file system has been mounted with the direct_io option, the file system *must* always write *all* the provided data.

i changed uuless to unless is ok.

and i think with should be without?