### PR TITLE
pytest_catchlogs.py: Fixup utf8 copyright character

### DIFF
--- a/test/pytest_checklogs.py
+++ b/test/pytest_checklogs.py
@@ -2,7 +2,7 @@
 '''
 pytest_checklogs.py - this file is part of S3QL.
 
-Copyright © 2008 Nikolaus Rath <Nikolaus@rath.org>
+Copyright (C) 2008 Nikolaus Rath <Nikolaus@rath.org>
 
 This work can be distributed under the terms of the GNU GPLv3.
 


### PR DESCRIPTION
This fixes build with python2.7
```
	pybuild --test -i python{version} -p 2.7
I: pybuild base:217: cd /<<BUILDDIR>>/python-llfuse-1.3.2+dfsg/.pybuild/cpython2_2.7_llfuse/build; python2.7 -m pytest --installed "/<<BUILDDIR>>/python-llfuse-1.3.2+dfsg/test/"
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/lib/python2.7/dist-packages/pytest.py", line 73, in <module>
    raise SystemExit(pytest.main())
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 50, in main
    config = _prepareconfig(args, plugins)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 160, in _prepareconfig
    pluginmanager=pluginmanager, args=args)
  File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 617, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 222, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 216, in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
  File "/usr/lib/python2.7/dist-packages/pluggy/callers.py", line 196, in _multicall
    gen.send(outcome)
  File "/usr/lib/python2.7/dist-packages/_pytest/helpconfig.py", line 68, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/usr/lib/python2.7/dist-packages/pluggy/callers.py", line 77, in get_result
    _reraise(*ex)  # noqa
  File "/usr/lib/python2.7/dist-packages/pluggy/callers.py", line 180, in _multicall
    res = hook_impl.function(*args)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 943, in pytest_cmdline_parse
    self.parse(args)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 1108, in parse
    self._preparse(args, addopts=addopts)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 1079, in _preparse
    args=args, parser=self._parser)
  File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 617, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 222, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/lib/python2.7/dist-packages/pluggy/__init__.py", line 216, in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
  File "/usr/lib/python2.7/dist-packages/pluggy/callers.py", line 201, in _multicall
    return outcome.get_result()
  File "/usr/lib/python2.7/dist-packages/pluggy/callers.py", line 77, in get_result
    _reraise(*ex)  # noqa
  File "/usr/lib/python2.7/dist-packages/pluggy/callers.py", line 180, in _multicall
    res = hook_impl.function(*args)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 989, in pytest_load_initial_conftests
    self.pluginmanager._set_initial_conftests(early_config.known_args_namespace)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 311, in _set_initial_conftests
    self._try_load_conftest(anchor)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 317, in _try_load_conftest
    self._getconftestmodules(anchor)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 342, in _getconftestmodules
    mod = self._importconftest(conftestpath)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 378, in _importconftest
    self.consider_conftest(mod)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 401, in consider_conftest
    self.register(conftestmodule, name=conftestmodule.__file__)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 256, in register
    self.consider_module(plugin)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 407, in consider_module
    self._import_plugin_specs(getattr(mod, 'pytest_plugins', []))
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 412, in _import_plugin_specs
    self.import_plugin(import_spec)
  File "/usr/lib/python2.7/dist-packages/_pytest/config.py", line 429, in import_plugin
    __import__(importspec)
  File "/<<BUILDDIR>>/python-llfuse-1.3.2+dfsg/test/pytest_checklogs.py", line 5
SyntaxError: Non-ASCII character '\xc2' in file /<<BUILDDIR>>/python-llfuse-1.3.2+dfsg/test/pytest_checklogs.py on line 6, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
E: pybuild pybuild:330: test: plugin distutils failed with: exit code=1: cd /<<BUILDDIR>>/python-llfuse-1.3.2+dfsg/.pybuild/cpython2_2.7_llfuse/build; python2.7 -m pytest --installed "{dir}/test/"
```