### PR TITLE
default_options: remove nonempty for non-Darwin, too

### DIFF
--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -213,12 +213,8 @@ def getxattr(path, name, size_t size_guess=128, namespace='user'):
 #   active, it's expected to improve performance because we move pages from the
 #   page instead of copying them.
 #
-if os.uname()[0] == 'Darwin':
-    default_options = frozenset(('big_writes', 'default_permissions',
-                                 'no_splice_read', 'splice_write', 'splice_move'))
-else:
-    default_options = frozenset(('big_writes', 'nonempty', 'default_permissions',
-                                 'no_splice_read', 'splice_write', 'splice_move'))
+default_options = frozenset(('big_writes', 'default_permissions',
+                             'no_splice_read', 'splice_write', 'splice_move'))
 
 def init(ops, mountpoint, options=default_options):
     '''Initialize and mount FUSE file system


### PR DESCRIPTION
"-o nonempty" has been removed in libfuse 3 [1].

1: https://github.com/libfuse/libfuse/commit/0bef21e