### PR TITLE
doc: improve llfuse.default_options

### DIFF
--- a/rst/data.rst
+++ b/rst/data.rst
@@ -25,6 +25,33 @@
    (The :samp:`fsname=<foo>` option is guaranteed never to be included in the
    default options, so you can always safely add it to the set).
 
+   The default options are:
+
+   * ``default_permissions`` enables permission checking by kernel.
+     Without this any umask (or uid/gid) would not have an effect.
+
+   * ``splice_write`` just means to use splice if possible (i.e., if data is
+     passed in a fd), and can be overriden using FUSE_BUF_NO_SPLICE. So it's a
+     good idea to always activate it.
+
+   * ``splice_read`` means that requests are spliced from the fuse fd to a
+     (thread-specific) intermediate pipe (this is presumably done to prevent
+     the write handler from reading part of the next request). If splice_read
+     is not set, fuse instead reads the whole request into memory and passes
+     this buffer along.  If we eventually read the request into a buffer anyway
+     (as we have to if we want to create a Python object), using splice_read()
+     is thus expected to *decrease* performance because of the intermediate
+     pipe.
+
+   * ``splice_move`` is a no-op as of Linux 2.6.21. However, it will become
+     active as soon as some problems with the initial implementation have been
+     solved.  If active, it's expected to improve performance because we move
+     pages from the page instead of copying them.
+
+   * ``nonempty`` allows mounts over non-empty file/dir.
+
+   * ``big_writes`` enables larger than 4kB writes.
+
    .. versionadded:: 0.42
 
 .. autoexception:: FUSEError

--- a/rst/data.rst
+++ b/rst/data.rst
@@ -25,6 +25,8 @@
    (The :samp:`fsname=<foo>` option is guaranteed never to be included in the
    default options, so you can always safely add it to the set).
 
+   .. versionadded:: 0.42
+
 .. autoexception:: FUSEError
 
 .. autoclass:: RequestContext

--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -194,25 +194,6 @@ def getxattr(path, name, size_t size_guess=128, namespace='user'):
     finally:
         stdlib.free(buf)
 
-# Default options:
-#
-# * splice_write just means to use splice if possible (i.e., if data is passed
-#   in a fd), and can be overriden using FUSE_BUF_NO_SPLICE. So it's a good idea
-#   to always activate it.
-#
-# * splice_read means that requests are spliced from the fuse fd to a
-#   (thread-specific) intermediate pipe (this is presumably done to prevent the
-#   write handler from reading part of the next request). If splice_read is not
-#   set, fuse instead reads the whole request into memory and passes this buffer
-#   along.  If we eventually read the request into a buffer anyway (as we have
-#   to if we want to create a Python object), using splice_read() is thus
-#   expected to *decrease* performance because of the intermediate pipe.
-#
-# * splice_move is a no-op as of Linux 2.6.21. However, it will become active as
-#   soon as some problems with the initial implementation have been solved.  If
-#   active, it's expected to improve performance because we move pages from the
-#   page instead of copying them.
-#
 if os.uname()[0] == 'Darwin':
     default_options = frozenset(('big_writes', 'default_permissions',
                                  'no_splice_read', 'splice_write', 'splice_move'))


### PR DESCRIPTION
- add version information for when it was added

TODO:
 - ~~[ ] use `autodata` and consolidate documentation from `rst/data.rst` into the data's.~~
 - [x] it explains "splice_write", "splice_read" and "splice_move" already, "big_writes" and "nonempty" should be added.

[ci skip]