### PR TITLE
Add handle_signals option to llfuse.main

### DIFF
--- a/Changes.rst
+++ b/Changes.rst
@@ -4,6 +4,10 @@
 
 .. currentmodule:: llfuse
 
+dev (not released yet)
+======================
+* Add `handle_signals` option to `llfuse.main`
+
 Release 1.3.4 (2018-04-29)
 ==========================
 

--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -254,7 +254,7 @@ def init(ops, mountpoint, options=default_options):
 
     pthread_mutex_init(&exc_info_mutex, NULL)
 
-def main(workers=None):
+def main(workers=None, handle_signals=True):
     '''Run FUSE main loop
 
     *workers* specifies the number of threads that will process requests
@@ -266,12 +266,15 @@ def main(workers=None):
     if *workers* is ``1``). These (and all worker threads) are guaranteed to
     have terminated when `main` returns.
 
-    While this function is running, special signal handlers will be installed
-    for the *SIGTERM*, *SIGINT* (Ctrl-C), *SIGHUP*, *SIGUSR1* and *SIGPIPE*
-    signals. *SIGPIPE* will be ignored, while the other three signals will cause
+    *handle_signals* specifies if special signal handlers should be installed
+    for the time this function is running for the *SIGTERM*, *SIGINT* (Ctrl-C),
+    *SIGHUP*, *SIGUSR1* and *SIGPIPE* signals.
+    *SIGPIPE* will be ignored, while the other three signals will cause
     request processing to stop and the function to return.  *SIGINT* (Ctrl-C)
     will thus *not* result in a `KeyboardInterrupt` exception while this
     function is runnning.
+    Note setting *handle_signals* to `False` means you must handle the signals
+    by yourself and call `stop` to make the `main` returns.
 
     When the function returns because the file system has received an unmount
     request it will return `None`. If it returns because it has received a
@@ -295,8 +298,9 @@ def main(workers=None):
     # for "regular exit".
     exit_reason = signal.SIGKILL
     with contextlib.ExitStack() as on_exit:
-        set_signal_handlers()
-        on_exit.callback(lambda: restore_signal_handlers())
+        if handle_signals:
+            set_signal_handlers()
+            on_exit.callback(lambda: restore_signal_handlers())
 
         # Start notification handling thread
         t = threading.Thread(target=_notify_loop)

--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -266,13 +266,12 @@ def main(workers=None, handle_signals=True):
     if *workers* is ``1``). These (and all worker threads) are guaranteed to
     have terminated when `main` returns.
 
-    *handle_signals* specifies if special signal handlers should be installed
-    for the time this function is running for the *SIGTERM*, *SIGINT* (Ctrl-C),
-    *SIGHUP*, *SIGUSR1* and *SIGPIPE* signals.
-    *SIGPIPE* will be ignored, while the other three signals will cause
-    request processing to stop and the function to return.  *SIGINT* (Ctrl-C)
-    will thus *not* result in a `KeyboardInterrupt` exception while this
-    function is runnning.
+    Unless *handle_signals* is `False`, while this function is running, special
+    signal handlers will be installed for the *SIGTERM*, *SIGINT* (Ctrl-C),
+    *SIGHUP*, *SIGUSR1* and *SIGPIPE* signals. *SIGPIPE* will be ignored,
+    while the other three signals will cause request processing to stop
+    and the function to return.  *SIGINT* (Ctrl-C) will thus *not* result in
+    a `KeyboardInterrupt` exception while this function is runnning.
     Note setting *handle_signals* to `False` means you must handle the signals
     by yourself and call `stop` to make the `main` returns.
 


### PR DESCRIPTION
The other point discussed in #13 
Regarding how to test this, I'm not sure using `test_fs.py` would be great given this would mean modify `run_fs` (given it's were `llfuse.main` is called) and add some test related code there too (typically installing a custom signal handler)...