### PR TITLE
DEVELOPER_MODE=1 needs to be set manually, fixes #22

### DIFF
--- a/developer-notes/release-process.md
+++ b/developer-notes/release-process.md
@@ -1,5 +1,11 @@
-# Steps for Releasing a New Version #
+# Pre-release checks #
 
+- `export DEVELOPER_MODE=1`  # good idea to have this always set while developping
+- build_cython / build_ext
+- check for warnings/errors needing fixing
+
+# Releasing a new version #
+ * `export DEVELOPER_MODE=0`  # or just not have it set
  * Bump version in `setup.py`
  * Add release date to `Changes.txt`
  * Check `hg status -u`, if necessary run `hg purge` to avoid undesired files in the tarball.

--- a/setup.py
+++ b/setup.py
@@ -46,15 +46,11 @@ from distutils.version import LooseVersion
 basedir = os.path.abspath(os.path.dirname(sys.argv[0]))
 sys.path.insert(0, os.path.join(basedir, 'util'))
 
-ON_TRAVIS = os.environ.get('TRAVIS_OS_NAME') is not None
-
-# when running on developer machine / from a repo checkout:
+# when running with DEVELOPER_MODE=1 in the environment:
 # enable all warnings, abort on some warnings.
-# when running on travis-ci, do not use developer mode, so it
-# can compile and test even if there are e.g. deprecation warnings.
-DEVELOPER_MODE = os.path.exists(os.path.join(basedir, 'MANIFEST.in')) and not ON_TRAVIS
+DEVELOPER_MODE = os.getenv('DEVELOPER_MODE', '0') == '1'
 if DEVELOPER_MODE:
-    print('found MANIFEST.in, running in developer mode')
+    print('running in developer mode')
     warnings.resetwarnings()
     # We can't use `error`, because e.g. Sphinx triggers a
     # DeprecationWarning.


### PR DESCRIPTION
the automatic way caused lots of troubles:
- broke travis
- often broke tests with specific python versions or OSes

By default, we just want to compile it as long as there is nothing
serious enough to really break a compiler run.

DEVELOPER_MODE=1 can be used on the dev machine to enable more warnings
and to be way more strict.