### PR TITLE
use EACCES instead of EPERM for file permission errors, fixes #36

### DIFF
--- a/examples/lltest.py
+++ b/examples/lltest.py
@@ -99,7 +99,7 @@ class TestFs(llfuse.Operations):
         if inode != self.hello_inode:
             raise llfuse.FUSEError(errno.ENOENT)
         if flags & os.O_RDWR or flags & os.O_WRONLY:
-            raise llfuse.FUSEError(errno.EPERM)
+            raise llfuse.FUSEError(errno.EACCES)
         return inode
 
     def read(self, fh, off, size):

--- a/src/handlers.pxi
+++ b/src/handlers.pxi
@@ -694,7 +694,7 @@ cdef void fuse_access (fuse_req_t req, fuse_ino_t ino, int mask) with gil:
         if allowed:
             ret = fuse_reply_err(req, 0)
         else:
-            ret = fuse_reply_err(req, EPERM)
+            ret = fuse_reply_err(req, EACCES)
     except FUSEError as e:
         ret = fuse_reply_err(req, e.errno)
     except:

--- a/src/llfuse.pyx
+++ b/src/llfuse.pyx
@@ -25,7 +25,7 @@ from posix.types cimport mode_t, dev_t, off_t
 from libc.stdint cimport uint32_t
 from libc.stdlib cimport const_char
 from libc cimport stdlib, string, errno, dirent
-from libc.errno cimport ETIMEDOUT, EPROTO, EINVAL, EPERM, ENOMSG, ENOATTR
+from libc.errno cimport EACCES, ETIMEDOUT, EPROTO, EINVAL, ENOMSG, ENOATTR
 from posix.unistd cimport getpid
 from posix.time cimport timespec
 from posix.signal cimport (sigemptyset, sigaddset, SIG_BLOCK, SIG_SETMASK,

--- a/src/llfuse.pyx
+++ b/src/llfuse.pyx
@@ -25,7 +25,7 @@ from posix.types cimport mode_t, dev_t, off_t
 from libc.stdint cimport uint32_t
 from libc.stdlib cimport const_char
 from libc cimport stdlib, string, errno, dirent
-from libc.errno cimport EACCES, ETIMEDOUT, EPROTO, EINVAL, ENOMSG, ENOATTR
+from libc.errno cimport EACCES, ETIMEDOUT, EPROTO, EINVAL, EPERM, ENOMSG, ENOATTR
 from posix.unistd cimport getpid
 from posix.time cimport timespec
 from posix.signal cimport (sigemptyset, sigaddset, SIG_BLOCK, SIG_SETMASK,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -55,7 +55,7 @@ def test_lltest(tmpdir):
             assert fh.read() == 'hello world\n'
         with pytest.raises(IOError) as exc_info:
             open(filename, 'r+')
-        assert exc_info.value.errno == errno.EPERM
+        assert exc_info.value.errno == errno.EACCES
         with pytest.raises(IOError) as exc_info:
             open(filename + 'does-not-exist', 'r+')
         assert exc_info.value.errno == errno.ENOENT

--- a/test/test_fs.py
+++ b/test/test_fs.py
@@ -209,7 +209,7 @@ class Fs(llfuse.Operations):
         if inode != self.hello_inode:
             raise llfuse.FUSEError(errno.ENOENT)
         if flags & os.O_RDWR or flags & os.O_WRONLY:
-            raise llfuse.FUSEError(errno.EPERM)
+            raise llfuse.FUSEError(errno.EACCES)
         return inode
 
     def read(self, fh, off, size):


### PR DESCRIPTION
port of https://github.com/libfuse/pyfuse3/pull/28/files

issues:

https://github.com/libfuse/pyfuse3/issues/22
https://github.com/python-llfuse/python-llfuse/issues/36