### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 
 matrix:
     include:
-        - python: "3.4"
-          os: linux
-          dist: trusty
         - python: "3.5"
           os: linux
           dist: xenial

--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,7 @@ def main():
           keywords=['FUSE', 'python' ],
           package_dir={'': 'src'},
           packages=setuptools.find_packages('src'),
+          python_requires='>=3.5',
           tests_require=['pytest >= 3.4.0'],
           provides=['llfuse'],
           ext_modules=[Extension('llfuse', c_sources,

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,6 @@ def main():
                        'Intended Audience :: Developers',
                        'Programming Language :: Python',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.4',
                        'Programming Language :: Python :: 3.5',
                        'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',

--- a/test/travis-install.sh
+++ b/test/travis-install.sh
@@ -2,6 +2,5 @@
 
 set -e
 
-# as long as we test on python 3.4, we need pytest < 5.0
-pip install 'pytest<5.0' pytest-catchlog cython sphinx
+pip install pytest pytest-catchlog cython sphinx
 cython --version


### PR DESCRIPTION
Fixes https://github.com/python-llfuse/python-llfuse/issues/42.

Also: 

* Add `python_requires` to help pip
* Remove `sudo: required` from Travis CI, it no longer does anything https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
* Remove redundant code for unsupported Python versions (<=3.4)
* Upgrade Python syntax with https://github.com/asottile/pyupgrade `--py3-plus`