### PR TITLE
Remove py2 and py3<3.5 support, update syntax for py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: python
 
 matrix:

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python-LLFUSE is no longer actively developed and just receiving
 community-contributed maintenance to keep it alive for some time.
 Unless you are stuck with Python 2.x or libfuse 2.x, we recommend
 to use the pyfuse3_ module instead - see pyfuse3_porting_ for some
-hints.
+hints. If you are stuck on Python 2.x, use llfuse<1.4.0.
 
 Python-LLFUSE is a set of Python bindings for the low level FUSE_
 API. It requires at least FUSE 2.8.0 and supports both Python 2.x and

--- a/examples/lltest.py
+++ b/examples/lltest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 lltest.py - Example file system for Python-LLFUSE.
 
@@ -23,7 +22,6 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 import os
 import sys
@@ -52,7 +50,7 @@ log = logging.getLogger(__name__)
 
 class TestFs(llfuse.Operations):
     def __init__(self):
-        super(TestFs, self).__init__()
+        super().__init__()
         self.hello_name = b"message"
         self.hello_inode = llfuse.ROOT_INODE+1
         self.hello_data = b"hello world\n"

--- a/examples/tmpfs.py
+++ b/examples/tmpfs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 tmpfs.py - Example file system for Python-LLFUSE.
 
@@ -22,7 +21,6 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 import os
 import sys
@@ -68,7 +66,7 @@ class Operations(llfuse.Operations):
 
 
     def __init__(self):
-        super(Operations, self).__init__()
+        super().__init__()
         self.db = sqlite3.connect(':memory:')
         self.db.text_factory = str
         self.db.row_factory = sqlite3.Row

--- a/examples/tmpfs.py
+++ b/examples/tmpfs.py
@@ -53,12 +53,6 @@ else:
 
 log = logging.getLogger()
 
-# For Python 2 + 3 compatibility
-if sys.version_info[0] == 2:
-    def next(it):
-        return it.next()
-else:
-    buffer = memoryview
 
 class Operations(llfuse.Operations):
     '''An example filesystem that stores all data in memory
@@ -286,7 +280,7 @@ class Operations(llfuse.Operations):
             else:
                 data = data[:attr.st_size]
             self.cursor.execute('UPDATE inodes SET data=?, size=? WHERE id=?',
-                                (buffer(data), attr.st_size, inode))
+                                (memoryview(data), attr.st_size, inode))
         if fields.update_mode:
             self.cursor.execute('UPDATE inodes SET mode=? WHERE id=?',
                                 (attr.st_mode, inode))
@@ -381,7 +375,7 @@ class Operations(llfuse.Operations):
         data = data[:offset] + buf + data[offset+len(buf):]
 
         self.cursor.execute('UPDATE inodes SET data=?, size=? WHERE id=?',
-                            (buffer(data), len(data), fh))
+                            (memoryview(data), len(data), fh))
         return len(buf)
 
     def release(self, fh):

--- a/rst/conf.py
+++ b/rst/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Python-LLFUSE documentation build configuration file, created by
 # sphinx-quickstart on Sat Oct 16 14:14:40 2010.
@@ -47,8 +46,8 @@ master_doc = 'index'
 nitpicky = True
 
 # General information about the project.
-project = u'Python-LLFUSE'
-copyright = u'2010-2015, Nikolaus Rath'
+project = 'Python-LLFUSE'
+copyright = '2010-2015, Nikolaus Rath'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,8 +184,8 @@ htmlhelp_basename = 'llfusedoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'llfuse.tex', u'Python-LLFUSE Documentation',
-   u'Nikolaus Rath', 'manual'),
+  ('index', 'llfuse.tex', 'Python-LLFUSE Documentation',
+   'Nikolaus Rath', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/setup.py
+++ b/setup.py
@@ -107,14 +107,6 @@ def main():
         # accident.
         compile_args.append('-Werror=sign-compare')
 
-    # http://bugs.python.org/issue7576
-    if sys.version_info[0] == 3 and sys.version_info[1] < 2:
-        compile_args.append('-Wno-error=missing-field-initializers')
-
-    # http://bugs.python.org/issue969718
-    if sys.version_info[0] == 2:
-        compile_args.append('-fno-strict-aliasing')
-
     link_args = pkg_config('fuse', cflags=False, ldflags=True, min_ver='2.8.0')
     link_args.append('-lpthread')
     c_sources = ['src/llfuse.c', 'src/lock.c']
@@ -123,10 +115,6 @@ def main():
         link_args.append('-lrt')
     elif os.uname()[0] == 'Darwin':
         c_sources.append('src/darwin_compat.c')
-
-    install_requires = []
-    if sys.version_info[0] == 2:
-        install_requires.append('contextlib2')
 
     setuptools.setup(
           name='llfuse',
@@ -170,7 +158,6 @@ def main():
                 'version': ('setup.py', LLFUSE_VERSION),
                 'release': ('setup.py', LLFUSE_VERSION),
             }},
-          install_requires=install_requires,
           )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#-*- coding: us-ascii -*-
 '''
 setup.py
 
@@ -11,7 +10,6 @@ This file is part of Python-LLFUSE. This work may be distributed under
 the terms of the GNU LGPL.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 import sys
 import os
@@ -71,7 +69,7 @@ def main():
     else:
         fix_docutils()
 
-    with open(os.path.join(basedir, 'README.rst'), 'r') as fh:
+    with open(os.path.join(basedir, 'README.rst')) as fh:
         long_desc = fh.read()
 
     compile_args = pkg_config('fuse', cflags=True, ldflags=False, min_ver='2.8.0')

--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -324,13 +324,7 @@ def main(workers=None, handle_signals=True):
         tmp = exc_info
         exc_info = None
 
-        # The explicit version check works around a Cython bug with
-        # the 3-parameter version of the raise statement, c.f.
-        # https://github.com/cython/cython/commit/a6195f1a44ab21f5aa4b2a1b1842dd93115a3f42
-        if PY_MAJOR_VERSION < 3:
-            raise tmp[0], tmp[1], tmp[2]
-        else:
-            raise tmp[1].with_traceback(tmp[2])
+        raise tmp[1].with_traceback(tmp[2])
 
     if exit_reason == signal.SIGKILL:
         return None
@@ -519,13 +513,7 @@ def close(unmount=True):
         tmp = exc_info
         exc_info = None
 
-        # The explicit version check works around a Cython bug with
-        # the 3-parameter version of the raise statement, c.f.
-        # https://github.com/cython/cython/commit/a6195f1a44ab21f5aa4b2a1b1842dd93115a3f42
-        if PY_MAJOR_VERSION < 3:
-            raise tmp[0], tmp[1], tmp[2]
-        else:
-            raise tmp[1].with_traceback(tmp[2])
+        raise tmp[1].with_traceback(tmp[2])
 
 def invalidate_inode(fuse_ino_t inode, attr_only=False):
     '''Invalidate cache for *inode*

--- a/src/llfuse.pyx
+++ b/src/llfuse.pyx
@@ -36,8 +36,8 @@ from cpython.buffer cimport (PyObject_GetBuffer, PyBuffer_Release,
                              PyBUF_CONTIG_RO, PyBUF_CONTIG)
 cimport cpython.exc
 cimport cython
-from cpython.version cimport PY_MAJOR_VERSION
 from libc cimport signal
+import contextlib
 
 
 ######################
@@ -112,15 +112,8 @@ import sys
 import os.path
 import threading
 from pickle import PicklingError
-
-if PY_MAJOR_VERSION < 3:
-    from Queue import Queue
-    import contextlib2 as contextlib
-    str_t = bytes
-else:
-    from queue import Queue
-    str_t = str
-    import contextlib
+from queue import Queue
+str_t = str
 
 ##################
 # GLOBAL VARIABLES

--- a/src/misc.pxi
+++ b/src/misc.pxi
@@ -288,26 +288,16 @@ def _notify_loop():
 cdef str2bytes(s):
     '''Convert *s* to bytes
 
-    Under Python 2.x, just returns *s*. Under Python 3.x, converts
-    to file system encoding using surrogateescape.
+    Converts to file system encoding using surrogateescape.
     '''
-
-    if PY_MAJOR_VERSION < 3:
-        return s
-    else:
-        return s.encode(fse, 'surrogateescape')
+    return s.encode(fse, 'surrogateescape')
 
 cdef bytes2str(s):
     '''Convert *s* to str
 
-    Under Python 2.x, just returns *s*. Under Python 3.x, converts
-    from file system encoding using surrogateescape.
+    Converts from file system encoding using surrogateescape.
     '''
-
-    if PY_MAJOR_VERSION < 3:
-        return s
-    else:
-        return s.decode(fse, 'surrogateescape')
+    return s.decode(fse, 'surrogateescape')
 
 cdef strerror(int errno):
     try:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 test_api.py - Unit tests for Python-LLFUSE.
 
@@ -9,7 +8,6 @@ This file is part of Python-LLFUSE. This work may be distributed under
 the terms of the GNU LGPL.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 if __name__ == '__main__':
     import pytest

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -94,8 +94,6 @@ def test_tmpfs(tmpdir):
     else:
         umount(mount_process, mnt_dir)
 
-@pytest.mark.skipif(sys.version_info < (3,3),
-                    reason="requires python3.3")
 def test_passthroughfs(tmpdir):
     mnt_dir = str(tmpdir.mkdir('mnt'))
     src_dir = str(tmpdir.mkdir('src'))
@@ -270,11 +268,8 @@ def tst_readdir(mnt_dir):
     os.rmdir(subdir)
     os.rmdir(dir_)
 
-def tst_truncate_path(mnt_dir):
-    if sys.version_info < (3,0):
-        # 2.x has no os.truncate
-        return
 
+def tst_truncate_path(mnt_dir):
     assert len(TEST_DATA) > 1024
 
     filename = os.path.join(mnt_dir, name_generator())
@@ -329,20 +324,16 @@ def tst_utimens(mnt_dir, ns_tol=0):
 
     atime = fstat.st_atime + 42.28
     mtime = fstat.st_mtime - 42.23
-    if sys.version_info < (3,3):
-        os.utime(filename, (atime, mtime))
-    else:
-        atime_ns = fstat.st_atime_ns + int(42.28*1e9)
-        mtime_ns = fstat.st_mtime_ns - int(42.23*1e9)
-        os.utime(filename, None, ns=(atime_ns, mtime_ns))
+    atime_ns = fstat.st_atime_ns + int(42.28*1e9)
+    mtime_ns = fstat.st_mtime_ns - int(42.23*1e9)
+    os.utime(filename, None, ns=(atime_ns, mtime_ns))
 
     fstat = os.lstat(filename)
 
     assert abs(fstat.st_atime - atime) < 1e-3
     assert abs(fstat.st_mtime - mtime) < 1e-3
-    if sys.version_info >= (3,3):
-        assert abs(fstat.st_atime_ns - atime_ns) <= ns_tol
-        assert abs(fstat.st_mtime_ns - mtime_ns) <= ns_tol
+    assert abs(fstat.st_atime_ns - atime_ns) <= ns_tol
+    assert abs(fstat.st_mtime_ns - mtime_ns) <= ns_tol
 
     checked_unlink(filename, mnt_dir, isdir=True)
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 test_examples.py - Unit tests for Python-LLFUSE.
 
@@ -9,7 +8,6 @@ This file is part of Python-LLFUSE. This work may be distributed under
 the terms of the GNU LGPL.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 if __name__ == '__main__':
     import pytest
@@ -51,7 +49,7 @@ def test_lltest(tmpdir):
         wait_for_mount(mount_process, mnt_dir)
         assert os.listdir(mnt_dir) == [ 'message' ]
         filename = os.path.join(mnt_dir, 'message')
-        with open(filename, 'r') as fh:
+        with open(filename) as fh:
             assert fh.read() == 'hello world\n'
         with pytest.raises(IOError) as exc_info:
             open(filename, 'r+')

--- a/test/test_fs.py
+++ b/test/test_fs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 test_fs.py - Unit tests for Python-LLFUSE.
 
@@ -9,7 +8,6 @@ This file is part of Python-LLFUSE. This work may be distributed under
 the terms of the GNU LGPL.
 '''
 
-from __future__ import division, print_function, absolute_import
 import pytest
 import sys
 
@@ -82,7 +80,7 @@ def test_invalidate_entry(testfs):
 
 def test_invalidate_inode(testfs):
     (mnt_dir, fs_state) = testfs
-    with open(os.path.join(mnt_dir, 'message'), 'r') as fh:
+    with open(os.path.join(mnt_dir, 'message')) as fh:
         assert fh.read() == 'hello world\n'
         assert fs_state.read_called
         fs_state.read_called = False
@@ -105,7 +103,7 @@ def test_invalidate_inode(testfs):
 
 def test_notify_store(testfs):
     (mnt_dir, fs_state) = testfs
-    with open(os.path.join(mnt_dir, 'message'), 'r') as fh:
+    with open(os.path.join(mnt_dir, 'message')) as fh:
         llfuse.setxattr(mnt_dir, 'command', b'store')
         fs_state.read_called = False
         assert fh.read() == 'hello world\n'
@@ -130,7 +128,7 @@ def test_entry_timeout(testfs):
 def test_attr_timeout(testfs):
     (mnt_dir, fs_state) = testfs
     fs_state.attr_timeout = 1
-    with open(os.path.join(mnt_dir, 'message'), 'r') as fh:
+    with open(os.path.join(mnt_dir, 'message')) as fh:
         os.fstat(fh.fileno())
         assert fs_state.getattr_called
         fs_state.getattr_called = False
@@ -144,7 +142,7 @@ def test_attr_timeout(testfs):
 
 class Fs(llfuse.Operations):
     def __init__(self, cross_process):
-        super(Fs, self).__init__()
+        super().__init__()
         self.hello_name = b"message"
         self.hello_inode = llfuse.ROOT_INODE+1
         self.hello_data = b"hello world\n"

--- a/test/test_rounding.py
+++ b/test/test_rounding.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 test_api.py - Unit tests for Python-LLFUSE.
 
@@ -9,7 +8,6 @@ This file is part of Python-LLFUSE. This work may be distributed under
 the terms of the GNU LGPL.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 if __name__ == '__main__':
     import pytest

--- a/test/util.py
+++ b/test/util.py
@@ -17,11 +17,7 @@ import pytest
 import os
 import stat
 import time
-import sys
 
-# For Python 2 + 3 compatibility
-if sys.version_info[0] == 2:
-    subprocess.DEVNULL = open('/dev/null', 'w')
 
 def fuse_test_marker():
     '''Return a pytest.marker that indicates FUSE availability

--- a/test/util.py
+++ b/test/util.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 util.py - Utility functions for Python-LLFUSE unit tests.
 
@@ -9,7 +8,6 @@ This file is part of Python-LLFUSE. This work may be distributed under
 the terms of the GNU LGPL.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 import platform
 import subprocess

--- a/util/sphinx_cython.py
+++ b/util/sphinx_cython.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 '''
 sphinx_cython.py
 
@@ -11,7 +10,6 @@ This file is part of Python-LLFUSE. This work may be distributed under
 the terms of the GNU LGPL.
 '''
 
-from __future__ import division, print_function, absolute_import
 
 import re
 


### PR DESCRIPTION
Split out from https://github.com/python-llfuse/python-llfuse/pull/48:

* Remove redundant code for unsupported Python versions (<=3.4)
* Upgrade Python syntax with https://github.com/asottile/pyupgrade `--py3-plus`
* Remove `sudo: required` from Travis CI, it no longer does anything https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

