### PR TITLE
timestamp rounding tests: avoid y2038 issue

### DIFF
--- a/test/test_rounding.py
+++ b/test/test_rounding.py
@@ -22,8 +22,10 @@ def test_rounding():
     # all dates.
     entry = llfuse.EntryAttributes()
 
-    # Approximately 100 years, ending in 999
-    secs = 100 * 365 * 24 * 3600 + 999
+    # Approximately 67 years, ending in 999.
+    # Note: 67 years were chosen to avoid y2038 issues (1970 + 67 = 2037).
+    #       Testing these is **not** in scope of this test.
+    secs = 67 * 365 * 24 * 3600 + 999
     nanos = _NANOS_PER_SEC - 1
 
     total = secs * _NANOS_PER_SEC + nanos


### PR DESCRIPTION
100y was beyond y2038 and could lead to issues
not related to the rounding we are testing here.