### PR TITLE
add util/ to sys.path so the sphinx extension can be found

### DIFF
--- a/rst/conf.py
+++ b/rst/conf.py
@@ -13,7 +13,9 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.append(os.path.abspath('.'))
+import os, sys
+basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(basedir, 'util'))
 
 #pylint: disable-all
 #@PydevCodeAnalysisIgnore


### PR DESCRIPTION
note: this is also done in setup.py, but readthedocs does not use "setup.py build_docs".