### PR TITLE
test: fix integer overflow on 32-bit arches

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -340,8 +340,10 @@ def tst_rounding(mnt_dir, ns_tol=0):
     os.mkdir(filename)
     fstat = os.lstat(filename)
 
-    # Approximately 100 years
-    secs = 100 * 365 * 24 * 3600 + 999
+    # Approximately 67 years, ending in 999.
+    # Note: 67 years were chosen to avoid y2038 issues (1970 + 67 = 2037).
+    #       Testing these is **not** in scope of this test.
+    secs = 67 * 365 * 24 * 3600 + 999
     # Max nanos
     nanos = _NANOS_PER_SEC - 1
 


### PR DESCRIPTION
On 32-bit arches, the `secs` value used in tst_rounding overflows:

 Traceback (most recent call last):
   File "/tmp/autopkgtest.pj5DKH/build.qGL/src/test/test_examples.py", line 82, in test_tmpfs
     tst_rounding(mnt_dir)
   File "/tmp/autopkgtest.pj5DKH/build.qGL/src/test/test_examples.py", line 355, in tst_rounding
     os.utime(filename, None, ns=(atime_ns, mtime_ns))
 OverflowError: timestamp out of range for platform time_t

To fix this, use the `secs` value from the very similar test_rounding
test, since it does not overflow 32-bit integers.