### PR TITLE
Fix crash when channel is removed but _notify_queue still has events

### DIFF
--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -301,9 +301,11 @@ def main(workers=None, handle_signals=True):
             on_exit.callback(lambda: restore_signal_handlers())
 
         # Start notification handling thread
+        _notify_queue_shutdown.clear()
         t = threading.Thread(target=_notify_loop)
         t.daemon = True
         t.start()
+        on_exit.callback(_notify_queue_shutdown.set)
         on_exit.callback(_notify_queue.put, None, block=True, timeout=5)
 
         on_exit.callback(lambda: fuse_session_reset(session))

--- a/src/fuse_api.pxi
+++ b/src/fuse_api.pxi
@@ -313,6 +313,7 @@ def main(workers=None, handle_signals=True):
             session_loop_single()
         else:
             session_loop_mt(workers)
+    t.join()
 
     if exc_info:
         # Re-raise expression from request handler

--- a/src/llfuse.pyx
+++ b/src/llfuse.pyx
@@ -137,6 +137,9 @@ lock_released = NoLockManager.__new__(NoLockManager)
 cdef object _notify_queue
 _notify_queue = Queue(maxsize=1000)
 
+cdef object _notify_queue_shutdown
+_notify_queue_shutdown = threading.Event()
+
 # Exported for access from Python code
 # (in the Cython source, we want ENOATTR to refer
 #  to the C constant, not a Python object)

--- a/src/misc.pxi
+++ b/src/misc.pxi
@@ -267,7 +267,11 @@ def _notify_loop():
     while True:
         req = _notify_queue.get()
         if req is None:
-            return
+            break
+
+        if _notify_queue_shutdown.is_set():
+            # Just drain the queue
+            continue
 
         if req.kind == NOTIFY_INVAL_INODE:
             if req.attr_only:


### PR DESCRIPTION
After llfuse.main() exits the handler loop but before it returns, wait for the _notify_loop thread to terminate.

If we don't do this, when llfuse.close() calls `fuse_session_remove_chan()` while `_notify_loop` is still running in a separate thread, it will segfault when it attempts to use the channel that has just been removed.  This is especially a problem with unit tests suites that set up and tear down the FUSE mount repeatedly in the same process.
